### PR TITLE
fix custom status message not being set on reconnect

### DIFF
--- a/events.go
+++ b/events.go
@@ -210,5 +210,8 @@ func (b *Bot) OnResume(s *discordgo.Session, r *discordgo.Resumed) {
 		time.Sleep(3 * time.Second)
 		b.LoadAllBacklogs()
 	}()
-	go s.UpdateStatus(0, "in the garbage")
+	err := s.UpdateStatus(0, *b.Config.StatusMessage)
+	if err != nil {
+		fmt.Println("error setting game:", err)
+	}
 }


### PR DESCRIPTION
Whilst running this bot I noticed that `statusmessage` doesn't get set correctly when the bot reconnects.
This makes it set the custom configured `statusmessage` from config.yml instead of the hardcoded "in the garbage" when OnResume happens.