### PR TITLE
Disable module mode so docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:latest
+ENV GO111MODULE=off
 
 RUN apt update -y --allow-insecure-repositories && apt upgrade -y && \ 
   apt install -y git && \
@@ -6,7 +7,7 @@ RUN apt update -y --allow-insecure-repositories && apt upgrade -y && \
   go get -u -v github.com/riking/AutoDelete/cmd/autodelete
 
 RUN mkdir -p /autodelete/data && \
-  cp "/go/src/github.com/riking/AutoDelete/docs/build.sh" /autodelete/
+  cp /go/src/github.com/riking/AutoDelete/docs/build.sh /autodelete/
 
 ENV HOME=/
 


### PR DESCRIPTION
As of go 1.16 module mode defaults to on which breaks the docker build since it depends on this being disabled. 

This change set GO111MODULE to off so that it's installed to src.


I would recommend pinning the go image to a specific version to prevent further issues.