### PR TITLE
Adjusted config.example.yml order

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -3,9 +3,9 @@ clientid:
 clientsecret:
 bottoken:
 adminuser:
+errorlog: ""
+backlog_limit: 200
 http:
   listen: "localhost:2202"
   public: "https://home.riking.org"
-backlog_limit: 200
-errorlog: ""
 statusmessage: "in the garbage"


### PR DESCRIPTION
Adjusted config.example.yml file order to make it work with the public docker image. Not sure if this bricks the public server, but the existing config file did _not_ run in the latest image without changing it to the one that is provided in the public manual here https://docs.google.com/document/d/1XnDCF7PLJkycHWBaPgbdwXTyycrmUdOo